### PR TITLE
Close p2p connection after rejecting since rejection packet doesn't c…

### DIFF
--- a/LaunchPadBooster/Networking/ModNetworking.cs
+++ b/LaunchPadBooster/Networking/ModNetworking.cs
@@ -304,6 +304,7 @@ namespace LaunchPadBooster.Networking
         HandshakeState = HandshakeType.Rejected,
         Message = message,
       }, NetworkChannel.GeneralTraffic, client);
+      NetworkManager.CloseP2PConnectionServer(client);
     }
 
     public static void WriteMessageType(RocketBinaryWriter writer, Type type)


### PR DESCRIPTION
…lose connection.

When investigating the timeout issue that occurs when a wrong password is entered, (see https://github.com/spacebuilder2020/Spacebuilder2020PatchMod/blob/main/Spacebuilder2020PatchMod.cs#L44), I discovered that this same issue happens in the new code for launch pad booster.  This blocks a local client from rejoining a hosted server after being rejected.

The fix is to close the steam connection.  (client.disconnect()) would also work but since the client isn't yet registered with the game, the only thing that has to be closed is the steam connection.