### PR TITLE
Fix exception during loading on the beta branch: 0.2.5898.25997

### DIFF
--- a/LaunchPadBooster/PrefabPatch.cs
+++ b/LaunchPadBooster/PrefabPatch.cs
@@ -1,6 +1,7 @@
 using Assets.Scripts.Objects;
 using HarmonyLib;
 using LaunchPadBooster.Utils;
+using UnityEngine;
 
 namespace LaunchPadBooster
 {
@@ -30,8 +31,21 @@ namespace LaunchPadBooster
     {
       // add all prefabs to worldmanager first so setup can find other mods prefabs
       foreach (var mod in Mod.AllMods)
+      {
         foreach (var prefab in mod.Prefabs)
-          WorldManager.Instance.AddPrefab(prefab);
+        {
+          if (!WorldManager.Instance.SourcePrefabs.Contains(prefab))
+          {
+            WorldManager.Instance.SourcePrefabs.Add(prefab);
+            Debug.Log($"Add prefab to WorldManager: {prefab.name}");
+          }
+          else
+          {
+            Debug.Log($"Already contains prefab: {prefab.name}");
+          }
+        }
+      }
+
       foreach (var mod in Mod.AllMods)
         foreach (var setup in mod.Setups)
           setup.Run(mod.Prefabs);


### PR DESCRIPTION
Method AddPrefab was removed from the world manager. The change is compatible with 0.2.5898.25997

MissingMethodException: Method not found: void .WorldManager.AddPrefab(Assets.Scripts.Objects.Thing)