### PR TITLE
Fix OverflowException when serializing mod info with many mods

### DIFF
--- a/LaunchPadBooster/Networking/ModNetworking.cs
+++ b/LaunchPadBooster/Networking/ModNetworking.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using Assets.Scripts;
 using Assets.Scripts.Networking;
@@ -34,12 +35,45 @@ public static class ModNetworking
   );
   private static ConfirmationPanelDelegate ShowConfirmationPanel;
 
+  private const int NetworkBufferSize = 65536;
+
+  private static void ResizeNetworkBuffers()
+  {
+    try
+    {
+      var flags = BindingFlags.Static | BindingFlags.NonPublic;
+      var managerType = typeof(NetworkManager);
+
+      var bufferField = managerType.GetField("Buffer", flags);
+      if (bufferField != null)
+        bufferField.SetValue(null, new byte[NetworkBufferSize]);
+      else
+        Debug.LogError("[LaunchPadBooster] Could not find NetworkManager.Buffer field");
+
+      var writerField = managerType.GetField("_messageWriter", flags);
+      if (writerField != null)
+      {
+        var oldWriter = (RocketBinaryWriter)writerField.GetValue(null);
+        writerField.SetValue(null, new RocketBinaryWriter(NetworkBufferSize));
+        oldWriter?.Dispose();
+      }
+      else
+        Debug.LogError("[LaunchPadBooster] Could not find NetworkManager._messageWriter field");
+    }
+    catch (Exception ex)
+    {
+      Debug.LogError($"[LaunchPadBooster] Failed to resize network buffers: {ex}");
+    }
+  }
+
   internal static void Initialize()
   {
     lock (initLock)
     {
       if (initialized)
         return;
+
+      ResizeNetworkBuffers();
 
       var harmony = new Harmony("LaunchPadBooster.Networking");
       harmony.CreateClassProcessor(typeof(ModNetworkPatches), true).Patch();


### PR DESCRIPTION
`SerializeServerModInfo` appends mod names, versions, and message type names to `VerifyPlayerRequest` via a Harmony postfix, but the game's `NetworkManager` uses a fixed 1024-byte buffer for both reading and writing network messages. With enough multiplayer-required mods, the serialized data exceeds 1024 bytes, causing `OverflowException: buffer too small for message` in `RocketBinaryWriter.Ensure`. On the read side, `ReceiveEvents` also rejects any packet exceeding the same 1024-byte `Buffer`, so clients can't receive the message either.

This adds a reflection-based resize of both `NetworkManager.Buffer` and `NetworkManager._messageWriter` to 64KB during `ModNetworking.Initialize()`, before any network messages are sent.

Related: StationeersLaunchPad/StationeersLaunchPad#97 (closed as base game issue, but the overflow is caused by LPB's postfix appending unbounded data to a fixed-size message)

Tested with a 60+ mod pack that previously crashed on player connect. Both server and client connect successfully after the fix.